### PR TITLE
Remove DVC feature from devcontainer.json

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -6,7 +6,6 @@
       "ghcr.io/devcontainers/features/nvidia-cuda:1": {
         "installCudnn": true
       },
-      "ghcr.io/iterative/features/dvc:1": {},
       "ghcr.io/iterative/features/nvtop:1": {}
     },
     "extensions": [


### PR DESCRIPTION
Whilst working through https://github.com/iterative/features/issues/15 I realised that the DVC feature is not required by this project as DVC is installed as a module in the `postCreateCommand`. Should give a slight startup time improvement when creating new Codespaces. 